### PR TITLE
Relocate materializations and tags for yaml files

### DIFF
--- a/models/mart/mart.yml
+++ b/models/mart/mart.yml
@@ -1,0 +1,10 @@
+version: 2
+
+name: sf_dbt
+
+sf_dbt:
+  models:
+    mart:
+      +schema: mart
+      materialized: view
+      tags: ['mart']

--- a/models/staging/stage.yml
+++ b/models/staging/stage.yml
@@ -5,42 +5,30 @@ name: sf_dbt
 sf_dbt:
   models:
     staging:
+      materialized: view
+      tags: ['stage']
+      +schema: staging
+
       stage_customer:
-        materialized: view
         primary_key: [c_custkey]
-        tags: ['stage']
 
       stage_line_item:
-        materialized: view
         primary_key: [l_orderkey, l_partkey, l_suppkey]
-        tags: ['stage']
 
       stage_nation:
-        materialized: view
         primary_key: [c_custkey]
-        tags: ['stage']
 
       stage_orders:
-        materialized: view
         primary_key: [o_orderkey]
-        tags: ['stage']
 
       stage_parts:
-        materialized: view
         primary_key: [p_partkey]
-        tags: ['stage']
 
       stage_part_suppliers:
-        materialized: view
         primary_key: [ps_partkey, ps_suppkey]
-        tags: ['stage']
 
       stage_region:
-        materialized: view
         primary_key: [r_regionkey]
-        tags: ['stage']
 
       stage_suppliers:
-        materialized: view
         primary_key: [s_suppkey]
-        tags: ['stage']

--- a/models/transform/transform.yml
+++ b/models/transform/transform.yml
@@ -5,43 +5,34 @@ name: sf_dbt
 sf_dbt:
   models:
     transform:
+      +schema: transform
+      materialized: view
+      tags: ['transform']
+
       customers:
-        materialized: view
         primary_key: [customer_key]
-        tags: ['transform']
 
       int_order_items:
         materialized: ephemeral
         primary_key: [order_item_key]
-        tags: ['transform']
 
       order_items:
         primary_key: [order_item_key]
-        tags: ['transform']
 
       nations:
-        materialized: view
         primary_key: [nation_key]
-        tags: ['transform']
 
       orders:
-        materialized: view
         primary_key: [order_key]
-        tags: ['transform']
 
       part_suppliers:
-        materialized: view
         primary_key: [part_supplier_key]
-        tags: ['transform']
 
       parts:
         primary_key: [part_key]
-        tags: ['transform']
 
       regions:
         primary_key: [region_key]
-        tags: ['transform']
 
       suppliers:
         primary_key: [supplier_key]
-        tags: ['transform']


### PR DESCRIPTION
This PR relocates the specific configurations for each directory into a directory specific yaml file rather than the dbt project yaml as a whole. This allows us to more easily make generic specifications about the models contained within each directory