### PR TITLE
Add column level tagging functionality

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,6 +27,9 @@ clean-targets:         # directories to be removed by `dbt clean`
 on-run-start:
   - "{{ dbt_snow_mask.create_masking_policy('models') }}"
 
+on-run-end:
+  - "{{ snowflake_utils.apply_meta_as_tags(results) }}"
+
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 

--- a/models/mart/mart.yml
+++ b/models/mart/mart.yml
@@ -271,3 +271,6 @@ models:
         tests:
           - not_null
           - unique
+        meta:
+          database_tags:
+            status_tag_string: a

--- a/packages.yml
+++ b/packages.yml
@@ -1,9 +1,12 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.8.2
+    version: 1.1.1
 
   - package: calogica/dbt_expectations
     version: 0.10.1
 
   - package: entechlog/dbt_snow_mask
     version: 0.2.4
+
+  - package: Montreal-Analytics/snowflake_utils
+    version: 0.6.1


### PR DESCRIPTION
PR adds the Montreal-Analytics/snowflake_utils package to the packages YAML and applies its meta tagging functionality to one of the report tables inside the mart layer.